### PR TITLE
refactor:並列処理によるサムネイル生成処理への変更

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "image",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.38", features = ["derive"] }
 image = "0.25.6"
+rayon = "1.10.0"
 
 [[bin]]
 name = "thumbnail"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@ use clap::Parser;
 use std::{
     fs::{create_dir_all, read_dir, remove_dir_all},
     path::PathBuf,
-    sync::{Arc, Mutex},
-    thread,
 };
 
 #[derive(Parser)]
@@ -30,44 +28,113 @@ fn main() {
     }
     create_dir_all(&args.output).unwrap();
 
-    let mut all_paths = vec![];
-    for entry in read_dir(&args.input).unwrap() {
-        let entry = entry.unwrap();
-        let path = entry.path();
-        if path.is_dir() {
-            continue;
+    // 1． スレッド処理を分割して、各スレッドが独立して処理を行う実装
+    // Arc, Mutexを使って、スレッド間で共有するデータを管理する
+    // use std::sync::{Arc, Mutex};
+    // use std::thread;
+    // let mut handles = vec![];
+    // let mut all_paths = vec![];
+    // for entry in read_dir(&args.input).unwrap() {
+    //     let entry = entry.unwrap();
+    //     let path = entry.path();
+    //     if path.is_dir() {
+    //         continue;
+    //     }
+    //     all_paths.push(path);
+    // }
+
+    // let processed_count = Arc::new(Mutex::new(0));
+    // let chunk_size = (all_paths.len() + 3) / 4;
+
+    // for chunk in all_paths.chunks(chunk_size) {
+    //     let chunk = chunk.to_vec();
+    //     let processed_count = processed_count.clone();
+    //     let output = args.output.clone();
+    //     handles.push(thread::spawn(move || {
+    //         for path in chunk {
+    //             let output_path = output.join(path.file_name().unwrap());
+    //             let img = image::open(&path);
+    //             if let Ok(img) = img {
+    //                 let thumbnail = img.thumbnail(64, 64);
+    //                 thumbnail.save(output_path).unwrap();
+    //                 let mut writer = processed_count.lock().unwrap();
+    //                 *writer += 1;
+    //             }
+    //         }
+    //     }))
+    // }
+
+    // for handle in handles {
+    //     handle.join().unwrap();
+    // }
+
+    // println!(
+    //     "Processed {} images",
+    //     processed_count.as_ref().lock().unwrap()
+    // );
+
+    // 2. チャンネルを使って、スレッド間でメッセージを送受信する実装
+    // Producer-Consumerパターンを使用して、スレッド間でメッセージを送受信する
+    //
+    // use std::sync::mpsc::channel;
+    // let mut handles = vec![];
+    // let mut channels = vec![];
+    // let (counter_tx, counter_rx) = channel::<usize>();
+
+    // // recv側(サムネイル生成処理側)の立ち上げ
+    // for _ in 0..4 {
+    //     let (tx, rx) = channel::<PathBuf>();
+    //     channels.push(tx);
+    //     let counter_tx = counter_tx.clone();
+    //     let output = args.output.clone();
+    //     handles.push(thread::spawn(move || {
+    //         while let Ok(path) = rx.recv() {
+    //             let output_path = output.join(path.file_name().unwrap());
+    //             let img = image::open(&path);
+    //             if let Ok(img) = img {
+    //                 let thumbnail = img.thumbnail(64, 64);
+    //                 thumbnail.save(output_path).unwrap();
+    //                 counter_tx.send(1).unwrap();
+    //             }
+    //         }
+    //     }))
+    // }
+
+    // // send側(ファイル読み込み処理側)の立ち上げ
+    // // 処理対象ファイルパスの送信
+    // for (index, entry) in read_dir(&args.input).unwrap().enumerate() {
+    //     let entry = entry.unwrap();
+    //     let path = entry.path();
+    //     if path.is_dir() {
+    //         continue;
+    //     }
+    //     channels[index % channels.len()].send(path).unwrap();
+    // }
+    // // すべてのファイルを送信した後、各スレッドに終了を通知
+    // for channel in channels {
+    //     drop(channel);
+    // }
+    // for handle in handles {
+    //     handle.join().unwrap();
+    // }
+    // let processed_count = counter_rx.iter().count();
+    // println!("Processed {} images", processed_count);
+
+    // 3. rayonを使って、並列処理を行う実装
+    use rayon::prelude::*;
+    let items: Vec<_> = read_dir(&args.input).unwrap().collect();
+    let result = items.into_par_iter().map(|item| {
+        let item = item.unwrap();
+        let path = item.path();
+        let output_path = args.output.join(path.file_name().unwrap());
+        let img = image::open(&path);
+        if let Ok(img) = img {
+            let thumbnail = img.thumbnail(64, 64);
+            thumbnail.save(&output_path).unwrap();
+            1
+        } else {
+            0
         }
-        all_paths.push(path);
-    }
-
-    let processed_count = Arc::new(Mutex::new(0));
-    let mut handles = vec![];
-    let chunk_size = (all_paths.len() + 3) / 4;
-
-    for chunk in all_paths.chunks(chunk_size) {
-        let chunk = chunk.to_vec();
-        let processed_count = processed_count.clone();
-        let output = args.output.clone();
-        handles.push(thread::spawn(move || {
-            for path in chunk {
-                let output_path = output.join(path.file_name().unwrap());
-                let img = image::open(&path);
-                if let Ok(img) = img {
-                    let thumbnail = img.thumbnail(64, 64);
-                    thumbnail.save(output_path).unwrap();
-                    let mut writer = processed_count.lock().unwrap();
-                    *writer += 1;
-                }
-            }
-        }))
-    }
-
-    for handle in handles {
-        handle.join().unwrap();
-    }
-
-    println!(
-        "Processed {} images",
-        processed_count.as_ref().lock().unwrap()
-    );
+    });
+    println!("Processed {} images", result.sum::<u32>());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,18 +49,16 @@ fn main() {
         let processed_count = processed_count.clone();
         let output = args.output.clone();
         handles.push(thread::spawn(move || {
-            let mut local_count = 0;
             for path in chunk {
                 let output_path = output.join(path.file_name().unwrap());
                 let img = image::open(&path);
                 if let Ok(img) = img {
                     let thumbnail = img.thumbnail(64, 64);
                     thumbnail.save(output_path).unwrap();
-                    local_count += 1;
+                    let mut writer = processed_count.lock().unwrap();
+                    *writer += 1;
                 }
             }
-            let mut writer = processed_count.lock().unwrap();
-            *writer += local_count;
         }))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use std::{
     fs::{create_dir_all, read_dir, remove_dir_all},
     path::PathBuf,
+    sync::{Arc, Mutex},
+    thread,
 };
 
 #[derive(Parser)]
@@ -13,6 +15,12 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
+    if !args.input.exists() {
+        eprintln!("Input directory does not exist");
+        return;
+    }
+    println!("Processing images from {:?}", args.input);
+
     if args.output.exists() {
         println!("Output directory already exists. Deleting...");
         if let Err(e) = remove_dir_all(&args.output) {
@@ -22,27 +30,46 @@ fn main() {
     }
     create_dir_all(&args.output).unwrap();
 
-    let mut processed_count = 0;
-    if !args.input.exists() {
-        eprintln!("Input directory does not exist");
-        return;
-    }
-    println!("Processing images from {:?}", args.input);
-    for item in read_dir(&args.input).unwrap() {
-        let item = item.unwrap();
-        let input_path = item.path();
-        if input_path.is_dir() {
+    let mut all_paths = vec![];
+    for entry in read_dir(&args.input).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
             continue;
         }
-
-        let img = image::open(&input_path);
-        if let Ok(img) = img {
-            let thumbnail = img.thumbnail(64, 64);
-            let output_path = args.output.join(input_path.file_name().unwrap());
-            thumbnail.save(&output_path).unwrap();
-            processed_count += 1;
-        }
+        all_paths.push(path);
     }
 
-    println!("Processed {} images", processed_count)
+    let processed_count = Arc::new(Mutex::new(0));
+    let mut handles = vec![];
+    let chunk_size = (all_paths.len() + 3) / 4;
+
+    for chunk in all_paths.chunks(chunk_size) {
+        let chunk = chunk.to_vec();
+        let processed_count = processed_count.clone();
+        let output = args.output.clone();
+        handles.push(thread::spawn(move || {
+            let mut local_count = 0;
+            for path in chunk {
+                let output_path = output.join(path.file_name().unwrap());
+                let img = image::open(&path);
+                if let Ok(img) = img {
+                    let thumbnail = img.thumbnail(64, 64);
+                    thumbnail.save(output_path).unwrap();
+                    local_count += 1;
+                }
+            }
+            let mut writer = processed_count.lock().unwrap();
+            *writer += local_count;
+        }))
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!(
+        "Processed {} images",
+        processed_count.as_ref().lock().unwrap()
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn main() {
         };
         let path = item.path();
         if path.is_dir() {
-            eprintln!("Info: Skipping directory {:?}", path); // Optional: log skipped directories
+            eprintln!("Info: Skipping directory {:?}", path);
             return 0; // Indicate that this directory was not processed as an image
         }
         let file_name = match path.file_name() {
@@ -175,8 +175,6 @@ fn main() {
             }
             1
         } else {
-            // The original `img` variable (from line 130) holds the Result here.
-            // We can extract the error if it's an Err variant.
             if let Err(e) = img {
                 eprintln!("Warning: Failed to open image {:?}: {}. Skipping.", path, e);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,13 @@ fn main() {
             std::process::exit(1);
         }
     }
-    create_dir_all(&args.output).unwrap();
+    if let Err(e) = create_dir_all(&args.output) {
+        eprintln!(
+            "Error: Failed to create output directory {:?}: {}",
+            args.output, e
+        );
+        std::process::exit(1);
+    }
 
     // 1． スレッド処理を分割して、各スレッドが独立して処理を行う実装
     // Arc, Mutexを使って、スレッド間で共有するデータを管理する


### PR DESCRIPTION
# 概要

並列処理導入によるサムネイル生成処理の効率化

以下のパターンでの実装を検証

- Mutexを用いたスレッドセーフ処理
- channelを用いたProducer-Consumerパターン
- rayonクレートを用いた並列処理実装

Close #1 